### PR TITLE
Fix chrome indexer

### DIFF
--- a/src/bin/chrome_sync/main.rs
+++ b/src/bin/chrome_sync/main.rs
@@ -4,6 +4,7 @@ use chrono::{TimeZone, Utc};
 use personal_search::indexer;
 use rusqlite::{params, Connection};
 
+use std::fs;
 use std::io::prelude::*;
 use std::io::Read;
 
@@ -85,7 +86,11 @@ fn main() -> tantivy::Result<()> {
 
     match place {
         Some(place_file) => {
-            let conn = Connection::open(place_file).expect("opening sqlite file");
+            let tmp_dir = tempfile::TempDir::new().expect("tmp_dir");
+            let tempfile = tmp_dir.path().join("tmpfile");
+            let tempfile = tempfile.to_str().unwrap();
+            fs::copy(place_file, tempfile);
+            let conn = Connection::open(tempfile).expect("opening sqlite file");
 
             let mut stmt = conn.prepare("select visits.id as id, urls.url as url, urls.title as title, urls.visit_count as visit_count, urls.hidden as hidden , visits.visit_time as last_visit_date from visits   join urls on visits.url = urls.id ORDER BY visits.visit_time DESC;").expect("place prep");
             let places_iter = stmt

--- a/src/bin/chrome_sync/main.rs
+++ b/src/bin/chrome_sync/main.rs
@@ -89,7 +89,7 @@ fn main() -> tantivy::Result<()> {
             let tmp_dir = tempfile::TempDir::new().expect("tmp_dir");
             let tempfile = tmp_dir.path().join("tmpfile");
             let tempfile = tempfile.to_str().unwrap();
-            fs::copy(place_file, tempfile);
+            fs::copy(place_file, tempfile).unwrap();
             let conn = Connection::open(tempfile).expect("opening sqlite file");
 
             let mut stmt = conn.prepare("select visits.id as id, urls.url as url, urls.title as title, urls.visit_count as visit_count, urls.hidden as hidden , visits.visit_time as last_visit_date from visits   join urls on visits.url = urls.id ORDER BY visits.visit_time DESC;").expect("place prep");

--- a/src/bin/firefox_sync/main.rs
+++ b/src/bin/firefox_sync/main.rs
@@ -109,7 +109,7 @@ fn main() -> tantivy::Result<()> {
             let tmp_dir = tempfile::TempDir::new().expect("tmp_dir");
             let tempfile = tmp_dir.path().join("tmpfile");
             let tempfile = tempfile.to_str().unwrap();
-            fs::copy(place_file, tempfile);
+            fs::copy(place_file, tempfile).unwrap();
             let conn = Connection::open(tempfile).expect("opening sqlite file");
             let mut stmt = conn
                 .prepare("SELECT id, fk, title FROM moz_bookmarks")


### PR DESCRIPTION
Dearerst Maintainer,

If chrome is running, then the `chrome_sync` indexer would panic:

```rust
thread 'main' panicked at 'place prep: SqliteFailure(Error { code: DatabaseBusy, extended_code: 5 }, Some("database is locked"))', src/bin/chrome_sync/main.rs:90:281
```

To prevent this, copy the sqlite db to a tempfile first, just like `firefox_sync`. Easy peasy.

Thank you for your time and consideration.

Database busy
But I have too many tabs
Open to quit now